### PR TITLE
docs: Add Video Intelligence demo breakdown to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Real-Time Drone Network Monitoring with Edge AI
+# Real-Time Drone Network Monitoring & Video Intelligence with Edge AI
 
 **MWC 2026 Demo — Adaptive Cloud Lab**
 
-A live kiosk demo showing autonomous drones monitoring 5G network quality across the Barcelona MWC venue area. Drones patrol waypoints around 12 Barcelona landmarks, return to base when battery is low, and are replaced by fresh drones with new callsigns — creating a continuous, realistic fleet lifecycle. The dashboard supports three telemetry data modes: **demo** (built-in synthetic data), **cloud** (Azure IoT Hub), and **edge** (Azure IoT Operations MQTT broker on-cluster). A small language model (Phi-4 Mini) running on an NVIDIA GPU at the edge provides real-time AI-powered insights — all orchestrated on AKS Arc (Azure Local).
+Two interconnected edge AI demos running on **AKS Arc (Azure Local)** — showcasing real-time telemetry monitoring and AI-powered video intelligence, all on commodity edge hardware with full data sovereignty.
+
+**Demo 1 — Drone Network Monitor:** A live kiosk showing autonomous drones monitoring 5G network quality across Barcelona. Drones patrol waypoints around 12 landmarks, return to base when battery is low, and are replaced by fresh drones with new callsigns — creating a continuous, realistic fleet lifecycle. The dashboard supports three telemetry data modes: **demo** (built-in synthetic data), **cloud** (Azure IoT Hub), and **edge** (Azure IoT Operations MQTT broker on-cluster). Phi-4 Mini running on an NVIDIA GPU at the edge provides real-time AI-powered insights.
+
+**Demo 2 — Drone Video Intelligence:** Upload drone footage and watch AI process it end-to-end on-premises. A custom YOLOv8 model detects cellular antennas frame-by-frame on the GPU, **Arc Video Indexer** creates a searchable video timeline with scenes, transcription, and OCR, and **Foundry Local (Phi-4 Mini)** generates natural-language summaries and answers questions about the footage — all without any data leaving the edge.
 
 ```mermaid
 graph LR
@@ -25,6 +29,23 @@ graph LR
 > *Detailed diagram with node IPs and platform services: [docs/architecture.md](docs/architecture.md)*
 >
 > *Deep dive — infrastructure, data flow, AI Insights on-premises, and edge computing details: [docs/explanation.md](docs/explanation.md)*
+
+### Video Intelligence Pipeline
+
+```mermaid
+graph LR
+    Upload["📹 Drone Video<br/>Upload (MP4)"]
+    YOLO["🔍 YOLOv8<br/>CV Inference<br/>(NVIDIA A2 GPU)"]
+    VI["🎬 Arc Video Indexer<br/>Scenes · OCR · Transcript"]
+    Foundry["🧠 Foundry Local<br/>Phi-4 Mini<br/>(NL Summary + Query)"]
+    UI["🌐 Video Dashboard<br/>Flask · Socket.IO"]
+    Export["📦 Export<br/>GeoJSON · CSV · JSON"]
+
+    Upload -->|"~10s"| YOLO -->|"~15-30s"| VI -->|"~60-120s"| Foundry -->|"~3-5s"| UI
+    UI --> Export
+```
+
+> *Dedicated deployment on the Mobile Azure Local stamp. Full demo guide: [docs/video-indexer-demo-guide.md](docs/video-indexer-demo-guide.md)*
 
 ---
 
@@ -60,6 +81,199 @@ Full observability stack with Prometheus, Grafana, and NVIDIA DCGM Exporter prov
 
 ---
 
+## Video Intelligence Demo — Full Breakdown
+
+The Video Intelligence demo is a **second, dedicated AKS Arc cluster** on the Mobile Azure Local stamp that showcases the full AI lifecycle at the edge: drone video upload → computer vision detection → video indexing → generative AI summarization — all on-premises.
+
+### How It Works (End-to-End)
+
+The pipeline has four sequential stages, each emitting real-time progress updates via WebSocket to the browser:
+
+```
+MP4 Upload → CV Inference (YOLOv8 on GPU) → Arc Video Indexer → Foundry Local Summary
+   ~10s            ~15-30s                      ~60-120s              ~3-5s
+```
+
+#### Stage 1: Video Upload
+
+The user drags-and-drops an MP4 file onto the dashboard (or clicks browse). The Flask backend:
+
+1. Saves the file to persistent storage (`/data/uploads/`)
+2. Creates a SQLite record for tracking state across pod restarts
+3. Adds the video to the in-memory video registry
+4. Emits a `processing_started` WebSocket event to the browser
+5. Spawns a background thread to run the processing pipeline
+6. Returns `202 Accepted` immediately — the browser shows a live progress UI
+
+#### Stage 2: CV Inference — YOLOv8 Object Detection
+
+A **YOLOv8s** model fine-tuned for cellular antenna detection runs on the NVIDIA A2 GPU:
+
+| Attribute | Value |
+|---|---|
+| Base model | YOLOv8s (Ultralytics) |
+| Training data | Roboflow RF100 Cell Towers + custom drone frames |
+| Classes | `cellular_antenna`, `microwave_dish`, and more |
+| Input size | 640×640 |
+| Format | ONNX (exported from PyTorch, runs via ONNX Runtime + CUDA) |
+| Speed | ~5-10 ms/frame (100-200 FPS on NVIDIA A2) |
+| VRAM | ~1 GB |
+
+**Per-frame output:**
+
+```json
+{
+  "frame": 1234,
+  "timestamp_str": "00:00:41.133",
+  "objects": [{
+    "label": "cellular_antenna",
+    "confidence": 0.91,
+    "bbox_xyxy": [412, 128, 487, 256]
+  }]
+}
+```
+
+The pipeline processes every frame, applies Non-Maximum Suppression, and produces structured detection JSON with bounding boxes, confidence scores, and timestamps. This converts raw video pixels into **searchable, queryable events**.
+
+> **Key insight:** *"This model was trained in Azure using cloud GPU compute, then exported as ONNX and deployed at the edge. Use the cloud for what it's good at (training), run inference where the data lives (the edge)."*
+
+#### Stage 3: Arc Video Indexer — Video Intelligence at the Edge
+
+**Azure AI Video Indexer enabled by Arc** runs as a Kubernetes extension directly on the cluster. After CV inference completes, the dashboard:
+
+1. Uploads the video to Arc Video Indexer via the [Arc VI REST API](https://github.com/Azure-Samples/azure-video-indexer-samples/blob/master/VideoIndexerEnabledByArc/Documentation/VideoIndexerArcApis.md)
+2. Polls status every 10 seconds (up to 30 minutes) — emitting `vi_progress` WebSocket events
+3. On completion, retrieves full insights: **scenes, shots, transcript, OCR, labels, keywords, faces, emotions**
+4. Persists the insights JSON to the SQLite database
+
+**What Video Indexer adds on top of our custom CV model:**
+
+| Capability | Source |
+|---|---|
+| Antenna detection + bounding boxes | Custom YOLOv8 pipeline |
+| Scene segmentation + shot detection | Arc Video Indexer |
+| Audio transcription | Arc Video Indexer |
+| OCR (on-screen text extraction) | Arc Video Indexer |
+| Face detection | Arc Video Indexer |
+| Keyword + topic extraction | Arc Video Indexer |
+| Searchable video timeline | Arc Video Indexer |
+
+> *"Video Indexer handles the heavy lifting of video intelligence — transcription, scene detection, search. We augment it with our own custom vision model for domain-specific objects like cell tower antennas. Best of both worlds."*
+
+**Authentication flow:**
+
+```
+Azure Service Principal (ClientSecretCredential)
+  → ARM Management API /generateAccessToken
+  → VI Bearer Token (cached ~58 min)
+  → Used for all VI API calls (upload, poll, get insights)
+```
+
+#### Stage 4: Foundry Local — AI Summarization & Interactive Query
+
+After both CV inference and Video Indexer complete, the dashboard calls **Foundry Local (Phi-4 Mini)** running on the same NVIDIA A2 GPU:
+
+1. Combines detection metadata + VI insights into a structured prompt
+2. Sends to the OpenAI-compatible `/v1/chat/completions` API endpoint
+3. Phi-4 Mini generates a natural-language executive summary
+4. The summary is stored and emitted via WebSocket as `analysis_complete`
+
+**Domain-specific system prompt:**
+> *"You are a drone video analyst working at a cell-tower inspection site. Given detection data from a drone flight analyzing cell tower antennas, provide a concise, professional summary of findings. Focus on structural integrity, anomalies, and maintenance recommendations."*
+
+**Sample interaction:**
+- **Visitor asks:** "What did the drone find?"
+- **Foundry Local responds:** "The drone flight detected 3 cellular antenna panels across 2 tower structures. All detections occurred between timestamps 0:41 and 2:15, at altitudes of 45-60 meters. Average detection confidence was 87%. The antennas appear to be standard macro cell panels oriented in a tri-sector configuration."
+
+Users can also ask follow-up questions via the dashboard's query input — each query sends the detection context + question to Phi-4 for contextual answers.
+
+### Video Dashboard UI
+
+A dark-themed kiosk web app (Flask + Socket.IO) where booth visitors can:
+
+1. **Upload drone footage** — Drag-and-drop or browse for MP4 files
+2. **Watch AI process the video** — Real-time 4-step progress: Upload → CV Detection → Video Indexing → AI Summary
+3. **View detections** — Video player with canvas-overlay bounding boxes at antenna locations
+4. **Browse the detection timeline** — Horizontal bar showing where in the video antennas were found
+5. **Read the AI summary** — Foundry Local (Phi-4 Mini) provides a natural-language summary of findings
+6. **Ask questions** — Type natural language queries: *"How many antennas were detected?" "Where are they located?"*
+7. **Explore VI insights** — Scenes, keywords, faces, OCR text extracted by Video Indexer
+8. **Export results** — Download detection data as GeoJSON, CSV, or JSON
+
+**Dashboard layout:**
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Header: Title + Status Dots (AI/VI Health) + Clock          │
+├─────────────────────────────────┬────────────────────────────┤
+│ Left Column:                    │ Right Column:              │
+│ • Video Player + Canvas Overlay │ • Stats (4 KPIs)           │
+│ • Upload Zone (Drag & Drop)     │ • Detection Timeline Bar   │
+│ • Processing Pipeline (4 steps) │ • AI Summary Card          │
+│                                 │ • VI Insights Panel        │
+│                                 │ • Detections Table         │
+│                                 │ • NL Query Input           │
+│                                 │ • Export Buttons            │
+├─────────────────────────────────┴────────────────────────────┤
+│ Footer: Video Tabs (horizontal scroll) + Upload Button       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### GPU Budget (NVIDIA A2, 16 GB VRAM)
+
+All three GPU workloads are time-sliced on a single NVIDIA A2 card:
+
+| Workload | VRAM | Duration |
+|---|---|---|
+| Foundry Local (Phi-4 Mini) | ~8 GB | Always-on |
+| YOLOv8s ONNX inference | ~1 GB | Per-video job (~30s) |
+| Arc Video Indexer | ~4-6 GB | During indexing windows |
+| **Headroom** | ~1-3 GB | Safety margin |
+
+### Recovery & Resilience
+
+The dashboard is designed for long-running kiosk operation:
+
+- **Pod restart recovery** — On startup, loads previously processed videos from SQLite and resumes VI polling for any videos that were mid-processing when the pod crashed
+- **Demo mode fallback** — If Foundry Local is unavailable, generates synthetic AI summaries and detection data so the demo always works
+- **Graceful degradation** — If Video Indexer is down, the pipeline skips VI indexing and shows YOLO detections + Foundry summary only
+
+### Deploying the Video Intelligence Demo
+
+```powershell
+# 1. Deploy Arc Video Indexer extension (requires Longhorn RWX storage)
+.\scripts\06-deploy-video-indexer.ps1
+
+# 2. Deploy the Foundry Local model for the VI cluster
+kubectl apply -f k8s/vi-foundry-local.yaml
+
+# 3. Build and deploy the Video Dashboard + CV inference container
+.\scripts\07-deploy-video-dashboard.ps1
+
+# 4. Verify everything is running
+kubectl get pods -n video-analysis
+kubectl get pods -n vi-foundry-mdl
+```
+
+**Video Dashboard URL:** `https://video.acx.mobile`
+
+> *Full demo guide with talk tracks, timing, and fallback options: [docs/video-indexer-demo-guide.md](docs/video-indexer-demo-guide.md)*
+
+### Cloud + Edge: The Model Training Story
+
+This is a deliberate architectural choice worth highlighting:
+
+| Phase | Where | Why |
+|---|---|---|
+| **Data labeling** | Azure (Roboflow / Custom Vision) | Cloud tools are better for collaborative labeling |
+| **Model training** | Azure ML (cloud GPU) | Training needs lots of compute, but only once |
+| **Model export** | Azure → ONNX | Open format, runs anywhere |
+| **Inference** | Azure Local (edge GPU) | Where the data lives, low latency, data sovereignty |
+
+> *"We used the cloud for what it's best at — scalable compute for training. Then we brought the trained model to the edge where the data lives. No raw video ever leaves these servers."*
+
+---
+
 ## Architecture Overview
 
 **Key components:**
@@ -73,6 +287,9 @@ Full observability stack with Prometheus, Grafana, and NVIDIA DCGM Exporter prov
 | **Azure IoT Operations (AIO)** | On-cluster MQTT broker (`aio-broker`) for edge-mode telemetry; AIO Dataflow selectively exports anonymized metrics to IoT Hub |
 | **Drone Telemetry Simulator** | Python script simulating autonomous drones with waypoint patrols, battery return-to-base, and fleet cycling |
 | **Live Dashboard** | Flask + Socket.IO + Leaflet.js real-time kiosk UI with rule-engine insights and Phi-4 AI summary; supports demo / cloud / edge data modes |
+| **Arc Video Indexer** | Azure AI Video Indexer enabled by Arc — Kubernetes extension for on-premises video intelligence (scene detection, transcription, OCR, search) |
+| **YOLOv8 CV Inference** | Custom-trained YOLOv8s model (ONNX) for cellular antenna detection on NVIDIA A2 GPU |
+| **Video Intelligence Dashboard** | Flask + Socket.IO kiosk UI for video upload, real-time processing pipeline, AI summarization, NL query, and export |
 
 ---
 
@@ -322,25 +539,33 @@ adaptivecloudlab-mwc26-demo/
 ├── docs/
 │   ├── architecture.md                 # Detailed Mermaid architecture diagram
 │   ├── explanation.md                  # Deep dive: infrastructure, data flow, edge AI insights
+│   ├── video-indexer-demo-guide.md     # Video Intelligence demo guide with talk tracks
 │   └── images/
 │       ├── drone-dashboard.png         # Drone Network Monitor screenshot
 │       └── grafana-dashboard.png       # Grafana cluster & GPU dashboard screenshot
 ├── config/
 │   ├── aks_arc_cluster.env.sample      # Infrastructure config template
-│   └── deployment.env.sample           # Deployment config template (ACR, DNS, etc.)
+│   ├── deployment.env.sample           # Deployment config template (ACR, DNS, etc.)
+│   └── vi-mobile.env                   # Video Indexer cluster config (Mobile stamp)
 ├── scripts/
 │   ├── 00-bootstrap-secrets.ps1        # RG, Key Vault, SSH keys, passwords
 │   ├── 01-create-cluster.ps1           # AKS Arc cluster + node pools
 │   ├── 02-install-platform.ps1         # Ingress, cert-mgr, Foundry, IoT Ops
 │   ├── 03-deploy-iot-simulation.ps1    # IoT Hub, device registration
 │   ├── 04-deploy-drone-demo.ps1        # Build containers, deploy to cluster
-│   └── 05-deploy-monitoring.ps1        # Prometheus, Grafana, DCGM GPU exporter
+│   ├── 05-deploy-monitoring.ps1        # Prometheus, Grafana, DCGM GPU exporter
+│   ├── 06-deploy-video-indexer.ps1     # Longhorn storage + Arc Video Indexer extension
+│   └── 07-deploy-video-dashboard.ps1   # Build + deploy Video Intelligence dashboard
 ├── k8s/
-│   ├── foundry-local.yaml             # Foundry Local Model + ModelDeployment CRDs
+│   ├── foundry-local.yaml             # Foundry Local Model + ModelDeployment CRDs (drone demo)
+│   ├── vi-foundry-local.yaml          # Foundry Local for Video Intelligence cluster
 │   ├── edge-ai.yaml                    # Ollama deployment (alternative GPU inference)
 │   ├── iot-ops-dataflow.yaml           # AIO Dataflow for selective cloud export (data sovereignty)
 │   ├── drone-demo.yaml.template       # Dashboard + Simulator K8s template (rendered at deploy time)
 │   ├── drone-demo-secrets.yaml         # Secrets template (gitignored)
+│   ├── video-dashboard.yaml            # Video Intelligence dashboard K8s manifests
+│   ├── video-dashboard.yaml.template   # Video dashboard template (rendered at deploy time)
+│   ├── cv-inference-job.yaml.template  # YOLOv8 batch inference K8s Job template
 │   ├── metallb-config.yaml            # MetalLB IP pool + L2 advertisement
 │   ├── monitoring-values.yaml         # Helm values for kube-prometheus-stack
 │   ├── dcgm-values.yaml              # Helm values for NVIDIA DCGM GPU exporter
@@ -356,6 +581,23 @@ adaptivecloudlab-mwc26-demo/
 │   └── static/
 │       ├── css/style.css               # Dark-theme kiosk styles
 │       └── js/app.js                   # Leaflet map + Socket.IO client
+├── video-dashboard/
+│   ├── app.py                          # Flask backend (video upload, pipeline orchestration, AI query)
+│   ├── vi_client.py                    # Arc Video Indexer API client (auth, upload, poll, insights)
+│   ├── requirements.txt                # Python dependencies (Flask, Socket.IO, azure-identity, httpx)
+│   ├── Dockerfile                      # Container build (python:3.12-slim)
+│   ├── .env.sample                     # Video dashboard env template
+│   ├── templates/
+│   │   └── index.html                  # Dark kiosk UI (video player, timeline, query, export)
+│   └── static/
+│       └── style.css                   # Neon green/cyan dark-theme styles
+├── cv-inference/
+│   ├── inference.py                    # YOLOv8 ONNX inference pipeline (frame-by-frame detection)
+│   ├── postprocess.py                  # YOLO output → bounding boxes + NMS
+│   ├── annotate.py                     # Draw detection overlays on video frames
+│   ├── export_geojson.py               # Convert detections to GeoJSON FeatureCollection
+│   ├── requirements.txt                # Dependencies (ultralytics, onnxruntime-gpu, opencv)
+│   └── Dockerfile                      # CUDA 12.2 runtime container for GPU inference
 ├── iot-simulation/
 │   ├── drone-telemetry-simulator.py    # 5-drone IoT Hub telemetry simulator
 │   ├── Dockerfile                      # Container build for simulator


### PR DESCRIPTION
## Summary

Adds a comprehensive Video Intelligence demo breakdown to the README, covering the full end-to-end pipeline that was built for the MWC 2026 demo.

### Changes

- **Updated title & intro** to cover both demos (Drone Network Monitor + Video Intelligence)
- **Added Video Intelligence pipeline diagram** (Mermaid): Upload → YOLOv8 → Arc Video Indexer → Foundry Local → Dashboard
- **Added full 4-stage breakdown:**
  - Stage 1: Video Upload (drag-and-drop, SQLite persistence, WebSocket progress)
  - Stage 2: CV Inference (YOLOv8s ONNX on NVIDIA A2 GPU, 5-10ms/frame)
  - Stage 3: Arc Video Indexer (scenes, transcript, OCR, faces, searchable timeline)
  - Stage 4: Foundry Local (Phi-4 Mini NL summarization + interactive query)
- **Documented:** Dashboard UI layout, GPU budget (time-sliced A2), recovery/resilience, deployment steps, cloud+edge training story
- **Updated Architecture table** with 3 new components
- **Updated Project Structure** with \ideo-dashboard/\, \cv-inference/\, VI scripts & manifests